### PR TITLE
Create post method used camome API

### DIFF
--- a/lib/perican/resource.rb
+++ b/lib/perican/resource.rb
@@ -1,3 +1,5 @@
+require 'json'
+
 module Perican
   module Resource
     class Base
@@ -8,6 +10,18 @@ module Perican
           :recipients  => recipients
         }
         Perican::Metadata.new(self, uid, date, summary, opts)
+      end
+
+      def to_json
+        JSON.generate({:content_type => self.class::TYPE,
+                       :resource => {:uid => uid,
+                                     :date => date,
+                                     :summary => summary,
+                                     :description => description,
+                                     :originator => originator,
+                                     :recipients => recipients
+                                    }
+                      })
       end
     end
 

--- a/lib/perican/resource/evernote.rb
+++ b/lib/perican/resource/evernote.rb
@@ -5,6 +5,8 @@ require "evernote_oauth"
 module Perican
   module Resource
     class Evernote < Base
+      TYPE = "evernote"
+
       def initialize(note)
         @note = note
       end

--- a/lib/perican/resource/mail.rb
+++ b/lib/perican/resource/mail.rb
@@ -4,6 +4,7 @@ require 'net/imap'
 module Perican
   module Resource
     class Mail < Base
+    TYPE = "mail"
 
       def initialize(mail)
         @mail = mail

--- a/lib/perican/resource/slack.rb
+++ b/lib/perican/resource/slack.rb
@@ -5,6 +5,8 @@ require 'json'
 module Perican
   module Resource
     class Slack < Base
+      TYPE = "slack"
+
       def initialize(message)
         @message = message
       end

--- a/lib/perican/resource/slack.rb
+++ b/lib/perican/resource/slack.rb
@@ -10,7 +10,7 @@ module Perican
       end
 
       def uid
-        @message.guid
+        #@message.guid
       end
 
       def date

--- a/lib/perican/resource/toggl.rb
+++ b/lib/perican/resource/toggl.rb
@@ -3,6 +3,8 @@ require 'toggl_api'
 module Perican
   module Resource
     class Toggl < Base
+      TYPE = "toggl"
+
       def initialize(time_entry)
         @time_entry = time_entry
       end

--- a/lib/perican/sender.rb
+++ b/lib/perican/sender.rb
@@ -1,0 +1,7 @@
+module Perican
+  module Sender
+    dir = File.dirname(__FILE__) + "/sender"
+
+    autoload :Camome, "#{dir}/camome.rb"
+  end
+end

--- a/lib/perican/sender/camome.rb
+++ b/lib/perican/sender/camome.rb
@@ -1,0 +1,32 @@
+require 'uri'
+require 'net/https'
+
+module Perican
+  module Sender
+    class Camome
+      def initialize
+        # URL is unkown ...
+        URL = 'https://...'
+        @headers = {"Content-Type" => "application/json"}
+      end
+
+      def post_resource(json)
+        return post_request(URL, json, @headers)
+      end
+
+      private
+
+      def post_request(url, param, headers = {})
+        uri = URI.parse(url)
+        https = Net::HTTP.new(uri.host, uri.port)
+        https.use_ssl = true
+
+        request = Net::HTTP::Post.new(uri.path)
+        request["Content-Type"] = headers["Content-Type"]
+        request.body = param
+        res = https.request(request)
+        return res
+      end
+    end
+  end
+end


### PR DESCRIPTION
#5 に関するPRである．

camome API を用いて resource を camome にポストするクラスを作成した．
camome API が要求するデータ形式は以下の通りである．
+ resource のタイプと resource のデータを持つ
+ json 形式

このため，以下の機能を実装した．
+ 各 resource にタイプを付与
+ resource を json 形式に変換するメソッド

今後の課題
+ camome API の URL が未設定
+ camome API を利用するメソッドは定義したが，このメソッドを具体的にどのように使用するかは議論の必要がある
+ slack の メッセージの id の取得ができていない（これについては新たな issue が必要と考えられる)
