### PR TITLE
Move to_json from Resource to Metadata

### DIFF
--- a/lib/perican/metadata.rb
+++ b/lib/perican/metadata.rb
@@ -8,9 +8,17 @@ module Perican
 
     attr_reader :uid, :date, :summary, :options
 
-    def initialize(conent, uid, date, summary, **options)
+    def initialize(content, uid, date, summary, **options)
       @options = {}
-      @conent, @uid, @date, @summary = conent, uid, date, summary
+      @content, @uid, @date, @summary = content, uid, date, summary
+    end
+
+    def to_hash
+      {:content_type => @content.class,
+       :uid => @uid,
+       :date => @date,
+       :summary => @summary,
+       :options => @options}
     end
   end
 

--- a/lib/perican/resource.rb
+++ b/lib/perican/resource.rb
@@ -1,5 +1,3 @@
-require 'json'
-
 module Perican
   module Resource
     class Base
@@ -12,16 +10,9 @@ module Perican
         Perican::Metadata.new(self, uid, date, summary, opts)
       end
 
-      def to_json
-        JSON.generate({:content_type => self.class::TYPE,
-                       :resource => {:uid => uid,
-                                     :date => date,
-                                     :summary => summary,
-                                     :description => description,
-                                     :originator => originator,
-                                     :recipients => recipients
-                                    }
-                      })
+      def to_hash
+        {:type =>self.class,
+         :source => self.source}
       end
     end
 

--- a/lib/perican/resource/evernote.rb
+++ b/lib/perican/resource/evernote.rb
@@ -5,8 +5,6 @@ require "evernote_oauth"
 module Perican
   module Resource
     class Evernote < Base
-      TYPE = "evernote"
-
       def initialize(note)
         @note = note
       end
@@ -33,6 +31,10 @@ module Perican
 
       def recipients
         []
+      end
+
+      def source
+        @note
       end
 
     end # class Evernote

--- a/lib/perican/resource/mail.rb
+++ b/lib/perican/resource/mail.rb
@@ -4,8 +4,6 @@ require 'net/imap'
 module Perican
   module Resource
     class Mail < Base
-    TYPE = "mail"
-
       def initialize(mail)
         @mail = mail
       end
@@ -32,6 +30,10 @@ module Perican
 
       def recipients
         (@mail.to || []) + (@mail.cc || [])
+      end
+
+      def source
+        @mail
       end
 
     end # class Mail

--- a/lib/perican/resource/slack.rb
+++ b/lib/perican/resource/slack.rb
@@ -5,8 +5,6 @@ require 'json'
 module Perican
   module Resource
     class Slack < Base
-      TYPE = "slack"
-
       def initialize(message)
         @message = message
       end
@@ -33,6 +31,10 @@ module Perican
 
       def recipients
         []
+      end
+
+      def source
+        @message
       end
 
     end # class Slack

--- a/lib/perican/resource/toggl.rb
+++ b/lib/perican/resource/toggl.rb
@@ -3,8 +3,6 @@ require 'toggl_api'
 module Perican
   module Resource
     class Toggl < Base
-      TYPE = "toggl"
-
       def initialize(time_entry)
         @time_entry = time_entry
       end
@@ -32,6 +30,11 @@ module Perican
       def recipients
         nil
       end
+
+      def source
+        @time_entry
+      end
+
     end # class Toggl
   end # module Resource
 end # module Perican

--- a/lib/perican/sender/camome.rb
+++ b/lib/perican/sender/camome.rb
@@ -1,16 +1,19 @@
 require 'uri'
 require 'net/https'
+require 'json'
 
 module Perican
   module Sender
     class Camome
       def initialize
-        # URL is unkown ...
+        # URL is unkown
         URL = 'https://...'
         @headers = {"Content-Type" => "application/json"}
       end
 
-      def post_resource(json)
+      # Post resource to camome with json format
+      def post_resource(resource)
+        json = resource_to_json(resource)
         return post_request(URL, json, @headers)
       end
 
@@ -26,6 +29,11 @@ module Perican
         request.body = param
         res = https.request(request)
         return res
+      end
+
+      def resource_to_json(resource)
+        JSON.generate({:clam => resource.metadate.to_hash,
+                       :resource => resource.to_hash})
       end
     end
   end


### PR DESCRIPTION
Resource クラスで定義されていた to_json メソッドを generate_to_json メソッドとして
sender/camome.rb のCamome クラスで定義し直した．
また，json 形式にするデータ本体も変更を加えた．
変更は以下の通りである．
+ ハッシュが持つキーは，clam と resource である
+ clam は，content_type，uid，date，summary，options を持つ
+ source は resource のデータ本体で，resource の継承クラスから source メソッドで取得する
+ clam が持つハッシュは Metadate クラスの to_hash メソッドで取得する
+ source が持つハッシュは Resource クラスの to_hash メソッドで取得する