### PR TITLE
Search and collect document by itself

### DIFF
--- a/examples/config.yml
+++ b/examples/config.yml
@@ -19,5 +19,9 @@ SLACK:
 TOGGL:
   TOKEN: "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
 
+# if you wants to ignore the hidden directory(.) when search, IGNORE_HIDDEN:true
+# default false
 DOCUMENT:
   PATH: "XXXXXXXXXXXXXXXXXXX"
+  IGNORE: "XXXXXX,XXXXXX"
+  IGNORE_HIDDEN: XXXX

--- a/lib/perican/builder.rb
+++ b/lib/perican/builder.rb
@@ -34,7 +34,9 @@ module Perican
       when :document
         conf = @config["DOCUMENT"]
         resource = Perican::Resource::Document
-        retriever = Perican::Retriever::Document.new(conf["PATH"])
+        retriever = Perican::Retriever::Document.new(conf["PATH"],
+                                                     conf["IGNORE"],
+                                                     conf["IGNORE_HIDDEN"])
       end
 
       collection = Perican::ResourceCollection.new

--- a/lib/perican/retriever/document.rb
+++ b/lib/perican/retriever/document.rb
@@ -36,7 +36,7 @@ module Perican
         documents = `#{command}`
         documents.split("\n").each do |doc|
           d = doc.split(",")
-          collection << {"uid" => d[0], "date" => d[1], "summary" => d[2]}
+          collection << {"uid" => d[0], "date" => d[1].lstrip, "summary" => "file://#{d[2].lstrip}"}
         end
         return collection
       end

--- a/lib/perican/retriever/document.rb
+++ b/lib/perican/retriever/document.rb
@@ -4,16 +4,36 @@ require 'json'
 module Perican
   module Retriever
     class Document
-      def initialize(path)
+      def initialize(path, ignore, ignore_hidden)
         @params = {
-          'path'   => path
+          'path'   => path,
+          'ignore' => ignore,
+          'ignore_hidden' => ignore_hidden
         }
       end
 
       def fetch
         collection = []
 
-        documents = File.open(File.expand_path(@params["path"])).read
+        path = File.expand_path(@params["path"])
+
+        if @params["ignore"] == nil
+          command = "find #{path} -atime -1 -exec stat -f '%i, %Sa, %N' -t '%F %T' {} \+"
+        else
+          ignore_str = "\\("
+          ignore = @params["ignore"].split(",")
+          ignore.each do |i|
+            i = i.lstrip
+            i = i.rstrip
+            ignore_str << " -name #{i}"
+          end
+          ignore_str << " \\)"
+          command = "find #{path} #{ignore_str} -prune -o -exec stat -f '%i, %Sa, %N' -t '%F %T' {} \+"
+        end
+
+        command << " | grep -v '\\/\\.'" if @params["ignore_hidden"] == true
+
+        documents = `#{command}`
         documents.split("\n").each do |doc|
           d = doc.split(",")
           collection << {"uid" => d[0], "date" => d[1], "summary" => d[2]}


### PR DESCRIPTION
「bin/perican document」を実行することにより，
findコマンドが実行されドキュメントを収集するように実装した．
また収集されるドキュメントの summary のフォーマットを以下のように変更した．
```
file://ファイルのパス
```

また，config.yml には，以下の設定が記述できる．
PATH: 検索対象とするディレクトリを指定
IGNORE: 検索対象から除外するディレクトリを指定
IGNORE_HIDDEN: 隠しディレクトリを検索対象から除外するか否かを指定