### PR TITLE
Dump event source when converting to hash

### DIFF
--- a/lib/perican/resource/event.rb
+++ b/lib/perican/resource/event.rb
@@ -2,6 +2,7 @@ require 'uri'
 require 'net/https'
 require 'json'
 require 'date'
+require 'base64'
 require 'google/apis/calendar_v3'
 
 module Perican
@@ -39,6 +40,10 @@ module Perican
         @event
       end
 
+      def to_hash
+        {:type => self.class,
+         :source => Base64.encode64(Marshal.dump(self.source))}
+      end
     end # class Event
   end # module Resource
 end # module Perican


### PR DESCRIPTION
#13 に対する PR である．

取得した resourse を POST する際に，Google Calendar API で取得したオブジェクトを Marshal モジュールのdump メソッドを用いて文字列に変換し，resource の source に 変換後の文字列を用いるようにした．
また，JSONに変換する際，ASCII-8BIT の文字の内， UTF-8 に変換することができない文字があったため，force_encoding メソッドを用いて文字コード情報を ISO-8859-1 に変えてから UTF-8 に変換している．

変換した文字列を含む JSON をPOST し，受信側で，Marshal モジュールの load メソッドを用いて元のオブジェクトに変換できることを確認した．
ただし，送信時に ISO-8859-1 から UTF-8 に変換しているため，ISO-8859-1 に変換してから，load する必要がある．
また，load メソッドを用いるためには，dump した時と同じ環境にする必要があるため，受信側で `google-api-client` という Gem をインストールし，load メソッドを用いるスクリプト内に `require 'google/apis/calendar_v3'`と記述する必要がある．
